### PR TITLE
Add .lua descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ All shaders have moved to https://github.com/exeldro/obs-shaderfilter/tree/maste
 | [media-hide.lua](media-hide.lua)                             | Hide media sources when ended                                                             |
 | [media-switch-scene.lua](media-switch-scene.lua)             | Select a media source and a scene to switch to after playback                             |
 | [media-visibility-source.lua](media-visibility-source.lua)   | Select a media source to change visibility after playback                                 |
-| [move-sources.lua](move-sources.lua)                         | test                                                                                      |
 | [ptt-toggle-hotkey.lua](ptt-toggle-hotkey.lua)               | Adds hotkey to enable push to talk                                                        |
 | [refresh-browsers.lua](refresh-browsers.lua)                 | Adds hotkey to refresh all browser sources                                                |
 | [scene-notes-save.lua](scene-notes-save.lua)                 | save [scene notes](https://obsproject.com/forum/resources/scene-notes-dock.1398/) to html |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # obs-lua
 
 All shaders have moved to https://github.com/exeldro/obs-shaderfilter/tree/master/data/examples
+
+| Item                                                         | Description                                                                               |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| [create_text_source.lua](create_text_source.lua)             | Adds hotkey to create text source                                                         |
+| [disable-source.lua](disable-source.lua)                     | Hide sources visible in a scene                                                           |
+| [enable-source.lua](enable-source.lua)                       | Add hotkeys to enable and disable a source on all scenes                                  |
+| [intro-live-outro.lua](enable-source.lua)                    | Intro, Live, and Outro                                                                    |
+| [media-cue.lua](media-cue.lua)                               | Select a media source and cue point                                                       |
+| [media-hide.lua](media-hide.lua)                             | Hide media sources when ended                                                             |
+| [media-switch-scene.lua](media-switch-scene.lua)             | Select a media source and a scene to switch to after playback                             |
+| [media-visibility-source.lua](media-visibility-source.lua)   | Select a media source to change visibility after playback                                 |
+| [move-sources.lua](move-sources.lua)                         | test                                                                                      |
+| [ptt-toggle-hotkey.lua](ptt-toggle-hotkey.lua)               | Adds hotkey to enable push to talk                                                        |
+| [refresh-browsers.lua](refresh-browsers.lua)                 | Adds hotkey to refresh all browser sources                                                |
+| [scene-notes-save.lua](scene-notes-save.lua)                 | save [scene notes](https://obsproject.com/forum/resources/scene-notes-dock.1398/) to html |
+| [source-cycler.lua](source-cycler.lua)                       | Sets a group source to act as a visibility loup                                           |
+| [source-lock-position.lua](source-lock-position.lua)         | Source lock position                                                                      |
+| [source-pairs.lua](source-pairs.lua)                         | Toggle visibility between 2 sources                                                       |
+| [source-toggle.lua](source-toggle.lua)                       | Toggle visibility between 2 sources                                                       |
+| [source-toggler.lua](source-toggler.lua)                     | Toggle between sources visible in a scene                                                 |
+| [source-toggler-delay.lua](source-toggler-delay.lua)         | Toggle between sources visible in a scene with delay                                      |
+| [source-visibility-groups.lua](source-visibility-groups.lua) | Make groups of sources that react on the visibility of the other sources in the group     |
+| [update-text.lua](update-text.lua)                           | Text source update using a file                                                           |


### PR DESCRIPTION
Hi, I hope this is helpful. 

Added a table with links to individual files and descriptions. 

Most descriptions are pulled directly from the scripts. Omitted move-sources.lua because it looks like it's still being tested? 
Added additional context for scene-notes-save.lua

Additional context may be helpful for intro-live-outro.lua and source-pairs.lua/source-toggle.lua 